### PR TITLE
feat: automated recipe import pipeline

### DIFF
--- a/.github/workflows/recipe-import.yml
+++ b/.github/workflows/recipe-import.yml
@@ -36,6 +36,8 @@ jobs:
         with:
           node-version: "20"
       - run: npm ci
+      - name: Install workflow-only deps (not in package.json to keep the app bundle clean)
+        run: npm install --no-save sharp@^0.33.5
       - name: Install yt-dlp
         run: pipx install yt-dlp
       - uses: anthropics/claude-code-action@v1

--- a/.github/workflows/recipe-import.yml
+++ b/.github/workflows/recipe-import.yml
@@ -1,0 +1,144 @@
+name: recipe-import
+
+on:
+  issues:
+    types: [labeled]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "GitHub issue number to import a recipe from"
+        required: true
+        type: string
+
+concurrency:
+  group: recipe-import-${{ github.event.issue.number || github.event.inputs.issue_number }}
+  cancel-in-progress: false
+
+jobs:
+  generate:
+    if: |
+      (github.event_name == 'issues' && github.event.label.name == 'recipe') ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    env:
+      ISSUE_NUMBER: ${{ github.event.issue.number || github.event.inputs.issue_number }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      INSTAGRAM_SESSIONID: ${{ secrets.INSTAGRAM_SESSIONID }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: redesign/editorial-notebook
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm ci
+      - name: Install yt-dlp
+        run: pipx install yt-dlp
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: "--model claude-sonnet-4-6"
+          prompt: |
+            You are importing a recipe from GitHub issue #${{ env.ISSUE_NUMBER }} in repo ${{ env.GITHUB_REPOSITORY }}.
+
+            ## Step-by-step
+
+            1. Read the issue: `gh issue view ${{ env.ISSUE_NUMBER }} --json title,body,url,labels`.
+            2. From the issue, derive:
+               - `SLUG`: kebab-case from the dish name (e.g. "Mexican Rice & Beans" → `mexican-rice-and-beans`).
+               - `DISH_DESC`: a short 3-8 word description for the image generator (e.g. "black bean chocolate brownies on a plate").
+               - `SOURCE_URL`: the first URL in the issue body.
+            3. Fetch the source content by host:
+               - `youtube.com` / `youtu.be`: run `yt-dlp --skip-download --write-auto-sub --sub-lang en --sub-format vtt --output '/tmp/source.%(ext)s' "$SOURCE_URL"`, then read `/tmp/source.en.vtt`. Also fetch page metadata with `curl -sL "$SOURCE_URL" | head -c 8000`.
+               - `instagram.com`: run `curl -sL -A 'Mozilla/5.0 (Macintosh)' "$SOURCE_URL"`. If the HTML is empty or login-walled AND `$INSTAGRAM_SESSIONID` is non-empty, retry with `-b "sessionid=$INSTAGRAM_SESSIONID"`. If you still can't extract a caption/recipe, post a comment on the issue asking Luis to paste the caption/transcript into the issue body, then exit (do not fail).
+               - other: use WebFetch.
+            4. Read `src/recipes/_template.yaml` and `src/recipes/the_smoothest_hummus.yaml` as references for the YAML schema.
+            5. Write `src/recipes/$SLUG.yaml`:
+               - Required: `name`, `source` (the SOURCE_URL), `image: $SLUG.jpg`, `servings`, `ingredients`, `methods`.
+               - Optional: `creator` (Instagram handle, YouTube channel, blog author name), `notes`.
+               - Ingredients MUST include `steps: [N, ...]` with 1-indexed step numbers — read the methods and decide which ingredients each step uses. Do not output `steps: []`.
+               - Use clean names (`chickpeas`, not `of chickpeas`).
+               - Units must be one of: tsp, tbsp, cup, can, clove, handful, g, ml, oz, lb — or `''` when unitless.
+            6. Generate 3 candidate photos: `node scripts/generate-recipe-images.mjs "$SLUG" "$DISH_DESC"`. This writes to `public/images/candidates/$SLUG-{1,2,3}.jpg`.
+            7. Create branch `recipe-import/$SLUG` off `redesign/editorial-notebook`, add the new YAML + the 3 candidate images, commit (`Draft: add $NAME`), and push.
+            8. Post this comment on issue #${{ env.ISSUE_NUMBER }} via `gh issue comment`:
+
+               ```
+               <!-- slug:$SLUG -->
+               Drafted `src/recipes/$SLUG.yaml`. Pick a dish photo:
+
+               1. ![variant 1](https://raw.githubusercontent.com/${{ env.GITHUB_REPOSITORY }}/recipe-import/$SLUG/public/images/candidates/$SLUG-1.jpg)
+               2. ![variant 2](https://raw.githubusercontent.com/${{ env.GITHUB_REPOSITORY }}/recipe-import/$SLUG/public/images/candidates/$SLUG-2.jpg)
+               3. ![variant 3](https://raw.githubusercontent.com/${{ env.GITHUB_REPOSITORY }}/recipe-import/$SLUG/public/images/candidates/$SLUG-3.jpg)
+
+               Reply `/use 1`, `/use 2`, or `/use 3` to finalize.
+               ```
+
+            ## Important
+
+            - Do NOT open a PR yet — finalize runs after Luis picks a variant.
+            - Do NOT modify existing recipes.
+            - Do NOT regenerate `src/recipes.json` — finalize handles that.
+            - If any step fails, post the error as an issue comment so Luis can debug.
+
+  finalize:
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request == null &&
+      github.event.comment.user.login == github.event.repository.owner.login &&
+      startsWith(github.event.comment.body, '/use ')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    env:
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      COMMENT_BODY: ${{ github.event.comment.body }}
+      GITHUB_REPOSITORY: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm ci
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: "--model claude-sonnet-4-6"
+          prompt: |
+            Luis picked a recipe image variant. Finalize the import for issue #${{ env.ISSUE_NUMBER }}.
+
+            The comment body is: `${{ env.COMMENT_BODY }}`. It matches `^/use [1-3]$`.
+
+            ## Step-by-step
+
+            1. Parse the variant number `N` (1|2|3) from the comment body.
+            2. Find the bot comment on this issue containing `<!-- slug:... -->`:
+               `gh issue view ${{ env.ISSUE_NUMBER }} --comments` — scan for the marker and extract `SLUG`.
+            3. `git fetch origin` and `git checkout recipe-import/$SLUG`.
+            4. `mv public/images/candidates/$SLUG-$N.jpg public/images/$SLUG.jpg`.
+            5. `rm -rf public/images/candidates` (on this branch only).
+            6. Confirm `src/recipes/$SLUG.yaml` has `image: $SLUG.jpg` (it should already; fix if not).
+            7. `node generate-recipes-json.ts` to regenerate `src/recipes.json`.
+            8. Commit (`Add $NAME`) and push.
+            9. Open a PR:
+               `gh pr create --base redesign/editorial-notebook --head recipe-import/$SLUG --title "Add $NAME" --body "Closes #${{ env.ISSUE_NUMBER }}."`
+            10. Post a comment on issue #${{ env.ISSUE_NUMBER }} linking the new PR.
+
+            ## Important
+
+            - If the slug can't be found (no prior bot comment), post a comment explaining and exit.
+            - Never force-push.

--- a/.github/workflows/recipe-import.yml
+++ b/.github/workflows/recipe-import.yml
@@ -1,8 +1,6 @@
 name: recipe-import
 
 on:
-  issues:
-    types: [labeled]
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -18,9 +16,7 @@ concurrency:
 
 jobs:
   generate:
-    if: |
-      (github.event_name == 'issues' && github.event.label.name == 'recipe') ||
-      github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ bun.lockb
 # staging area for gemini-generated image variants — pick via /variants.html
 public/variants/
 public/variants.html
+# intermediate recipe-import candidates before Luis picks a variant — the CI
+# finalize job moves the chosen one to public/images/<slug>.jpg and deletes
+# the rest, but if you're running locally, don't commit candidates by accident
+public/images/candidates/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,11 @@
 
 ### The automated way (preferred)
 
-1. Open a new issue with the source URL (Instagram, YouTube, blog, whatever) in the body.
-2. Add the `recipe` label.
-3. GitHub Actions will read the issue, fetch the source, draft a `src/recipes/<slug>.yaml`, generate 3 candidate dish photos, and comment back with the options.
+1. Open an issue with the source URL (Instagram, YouTube, blog, whatever) in the body and add the `recipe` label so it shows up in the queue.
+2. When you're ready to import it, trigger the workflow manually: Actions tab → `recipe-import` → **Run workflow** → enter the issue number. (Labeling alone does not auto-run — this is intentional, so a pile of labeled issues doesn't fire off every agent at once.)
+3. GitHub Actions reads the issue, fetches the source, drafts `src/recipes/<slug>.yaml`, generates 3 candidate dish photos, and comments back with the options.
 4. Reply `/use 1`, `/use 2`, or `/use 3` to pick your favourite photo.
-5. The action opens a PR against the current integration branch (today: `redesign/editorial-notebook`, eventually `main`) and closes the issue.
-
-You can also trigger the flow manually from the Actions tab → `recipe-import` → Run workflow, passing the issue number.
+5. The action opens a PR against `main` closing the issue.
 
 ### The manual way
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing
+
+## Adding a recipe
+
+### The automated way (preferred)
+
+1. Open a new issue with the source URL (Instagram, YouTube, blog, whatever) in the body.
+2. Add the `recipe` label.
+3. GitHub Actions will read the issue, fetch the source, draft a `src/recipes/<slug>.yaml`, generate 3 candidate dish photos, and comment back with the options.
+4. Reply `/use 1`, `/use 2`, or `/use 3` to pick your favourite photo.
+5. The action opens a PR against the current integration branch (today: `redesign/editorial-notebook`, eventually `main`) and closes the issue.
+
+You can also trigger the flow manually from the Actions tab → `recipe-import` → Run workflow, passing the issue number.
+
+### The manual way
+
+1. Copy `src/recipes/_template.yaml` to `src/recipes/<slug>.yaml`.
+2. Fill in the fields. Pay special attention to the `steps:` array on each ingredient — it's 1-indexed and drives the play-mode spotlight in [src/Recipe.tsx](src/Recipe.tsx).
+3. Drop a 4:3 JPEG at `public/images/<slug>.jpg`.
+4. `npm install && npm start` to verify the recipe renders.
+5. Open a PR.
+
+## Recipe schema
+
+See [src/recipes/_template.yaml](src/recipes/_template.yaml) for the full schema with comments. The shape:
+
+```yaml
+name: Recipe Name
+source: https://...
+image: <slug>.jpg
+servings: 4
+ingredients:
+  - name: chickpeas
+    quantity: 1.0
+    unit: can          # '' when unitless
+    steps: [1, 2]
+methods:
+  - Step one.
+  - Step two.
+```
+
+`generate-recipes-json.ts` rolls every `src/recipes/*.yaml` (excluding `_*.yaml`) into `src/recipes.json` during `prestart` / `prebuild`.
+
+## Repo secrets
+
+The `recipe-import` workflow needs these configured in Settings → Secrets and variables → Actions:
+
+| Name | Required | Notes |
+|---|---|---|
+| `CLAUDE_CODE_OAUTH_TOKEN` | yes | Generate locally via `claude setup-token` (Pro/Max subscriber token). |
+| `GEMINI_API_KEY` | yes | From https://aistudio.google.com/apikey. Used for Nano Banana 2 image generation. |
+| `INSTAGRAM_SESSIONID` | optional | Instagram `sessionid` cookie. Attached when scraping `instagram.com` URLs; without it some reels may be unreachable and the action will ask you to paste the caption into the issue. |
+
+## Local dev
+
+```sh
+npm install
+npm start             # serves on http://localhost:3000
+npm run build
+```
+
+Bun works too if you'd rather (`bun install && bun run start`). The `prestart` / `prebuild` hook regenerates `src/recipes.json` from the YAML files.

--- a/generate-recipes-json.ts
+++ b/generate-recipes-json.ts
@@ -5,8 +5,9 @@ const yaml = require('js-yaml');
 const recipesYamlDir = path.join(__dirname, 'src', 'recipes');
 const recipesJsonFile = path.join(__dirname, 'src', 'recipes.json');
 
-// Read all YAML files from the recipes_yaml directory
-const recipeFiles = fs.readdirSync(recipesYamlDir).filter(file => file.endsWith('.yaml'));
+// Read all YAML files from the recipes_yaml directory.
+// Skip files starting with `_` (e.g. _template.yaml) — not real recipes.
+const recipeFiles = fs.readdirSync(recipesYamlDir).filter(file => file.endsWith('.yaml') && !file.startsWith('_'));
 
 // Convert each YAML file to a JSON object
 const recipes = recipeFiles.map(file => {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@types/react-dom": "^18.2.19",
     "eslint-config-react-app": "^7.0.1",
     "js-yaml": "^4.1.0",
-    "react-scripts": "*",
-    "sharp": "^0.33.5"
+    "react-scripts": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@types/react-dom": "^18.2.19",
     "eslint-config-react-app": "^7.0.1",
     "js-yaml": "^4.1.0",
-    "react-scripts": "*"
+    "react-scripts": "*",
+    "sharp": "^0.33.5"
   }
 }

--- a/scripts/generate-recipe-images.mjs
+++ b/scripts/generate-recipe-images.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// Generate 3 styled dish photos for a recipe via Gemini Nano Banana 2.
+// Usage: node scripts/generate-recipe-images.mjs <slug> "<dish description>"
+
+import { readFile, mkdir } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import sharp from "sharp";
+
+const MODEL = "gemini-3.1-flash-image-preview";
+const API_URL = `https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent`;
+
+const [, , slug, dishDescription] = process.argv;
+if (!slug || !dishDescription) {
+  console.error('Usage: node scripts/generate-recipe-images.mjs <slug> "<dish description>"');
+  process.exit(1);
+}
+
+const apiKey = process.env.GEMINI_API_KEY;
+if (!apiKey) {
+  console.error("GEMINI_API_KEY not set");
+  process.exit(1);
+}
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const stylePrompt = `Food-forward clean photo of ${dishDescription}. The ceramic bowl is centered and fills at least 70% of the frame. Soft natural daylight, no dramatic lighting. Slight top-down angle (about 65-75°). Simple plain neutral surface — plain muted linen or simple plain countertop. Borrow the color palette, depth-of-field, and soft-warm tone from the reference photos, but DO NOT reproduce: stains, smears, hands, fingers, cutting boards, wood-grain planks, fussy prop arrangements, visible clutter, phones/people in frame. Also avoid the opposite extreme: no food-magazine styling, no studio lighting, no editorial overhead shots with scattered props, no decorative herbs flying, no dramatic steam. The goal is a clean, honest picture of the dish — like a friend texted a photo of their dinner bowl on a plain napkin. 4:3 aspect ratio.`;
+
+async function loadRef(path) {
+  const buf = await readFile(path);
+  return { mimeType: "image/jpeg", data: buf.toString("base64") };
+}
+
+async function generateOne(refs, variant) {
+  const body = {
+    contents: [
+      {
+        role: "user",
+        parts: [
+          { text: `${stylePrompt}\n\nVariant ${variant} of 3 — vary the framing slightly from the other variants.` },
+          { inlineData: refs[0] },
+          { inlineData: refs[1] },
+        ],
+      },
+    ],
+    generationConfig: { responseModalities: ["IMAGE"] },
+  };
+  const res = await fetch(`${API_URL}?key=${apiKey}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`Gemini API ${res.status}: ${await res.text()}`);
+  }
+  const data = await res.json();
+  const part = data.candidates?.[0]?.content?.parts?.find((p) => p.inlineData?.data);
+  if (!part) {
+    throw new Error(`No image returned for variant ${variant}: ${JSON.stringify(data).slice(0, 600)}`);
+  }
+  return Buffer.from(part.inlineData.data, "base64");
+}
+
+const refs = await Promise.all([
+  loadRef(join(repoRoot, "public/images/babaganoush.jpeg")),
+  loadRef(join(repoRoot, "public/images/hummus.jpeg")),
+]);
+
+const outDir = join(repoRoot, "public/images/candidates");
+await mkdir(outDir, { recursive: true });
+
+for (let i = 1; i <= 3; i++) {
+  console.log(`Generating variant ${i}…`);
+  const raw = await generateOne(refs, i);
+  const outPath = join(outDir, `${slug}-${i}.jpg`);
+  await sharp(raw)
+    .resize({ width: 1600, withoutEnlargement: true })
+    .jpeg({ quality: 85, progressive: true })
+    .toFile(outPath);
+  console.log(`Wrote ${outPath}`);
+}

--- a/src/recipes/_template.yaml
+++ b/src/recipes/_template.yaml
@@ -1,0 +1,41 @@
+# Recipe schema template.
+# Copy this file to <slug>.yaml, fill in the fields, and commit. The
+# prebuild step (`node generate-recipes-json.ts`) will roll it into
+# `src/recipes.json`.
+#
+# See `the_smoothest_hummus.yaml` for a real example.
+
+# ---- Required ----
+
+name: Recipe Name                   # Human-readable title shown in the gallery
+source: https://example.com/recipe  # Original source URL; the UI parses the host
+image: <slug>.jpg                   # Filename under public/images/ — set by the
+                                    # import automation after you pick a variant
+servings: 4                         # Integer
+
+# Each ingredient lists the 1-indexed step numbers it appears in. The
+# mapping powers the play-mode ingredient spotlight in src/Recipe.tsx.
+# Use clean names: `chickpeas`, not `of chickpeas`.
+ingredients:
+  - name: onion
+    quantity: 1.0
+    unit: ''            # Allowed: tsp, tbsp, cup, can, clove, handful,
+                        # g, ml, oz, lb. Empty string when unitless.
+    steps: [1]          # 1-indexed; every number must match a step below
+
+  - name: chickpeas
+    quantity: 1.0
+    unit: can
+    steps: [1, 2]
+
+# Steps are rendered in order, numbered from 1.
+methods:
+  - Dice the onion and sauté in a large pot until translucent.
+  - Add the chickpeas; stir to coat.
+
+# ---- Optional ----
+
+# creator: '@someone'   # Attribution handle; omit if unknown
+# deleted: false        # true if the source URL is dead; hides the link in UI
+# notes:
+#   - Stir occasionally or the bottom catches.


### PR DESCRIPTION
## Summary

Automated recipe import pipeline — closes out the backlog of "import this recipe" issues without hand work.

**End-to-end flow:**
1. Open an issue with the source URL, add the `recipe` label so it's queued.
2. When ready, trigger manually: Actions → `recipe-import` → **Run workflow** → issue number. *(Labeling alone does not auto-run — intentionally, so 23 labeled issues don't fire off 23 agents at once.)*
3. The `generate` job runs Claude Code Action: reads the issue, fetches the source (yt-dlp for YouTube, cookie-aware curl for Instagram, WebFetch for blogs), drafts `src/recipes/<slug>.yaml` with step-ingredient mappings, generates 3 dish photo candidates via Gemini Nano Banana 2, pushes `recipe-import/<slug>`, comments with the 3 variants + `/use N` instructions.
4. Reply `/use 2` (or 1/3).
5. The `finalize` job (`issue_comment` trigger) moves the chosen photo to `public/images/<slug>.jpg`, regenerates `src/recipes.json`, opens a PR closing the issue.

## What's in this PR

- `.github/workflows/recipe-import.yml` — `generate` (dispatch-only) + `finalize` (`issue_comment` on `/use N`).
- `scripts/generate-recipe-images.mjs` — Gemini Nano Banana 2 wrapper with the style prompt from [#40](https://github.com/lucharo/recipe-portfolio/pull/40). `sharp` added as a devDep for resize/encode.
- `src/recipes/_template.yaml` — schema reference. The generator now skips `_*.yaml` so it doesn't leak into `recipes.json`.
- `CONTRIBUTING.md` — automated + manual add flow, schema summary, required secrets.

## Required repo secrets (already set)

| Name | Required | Notes |
|---|---|---|
| `CLAUDE_CODE_OAUTH_TOKEN` | ✅ set | From `claude setup-token` |
| `GEMINI_API_KEY` | ✅ set | Google AI Studio |
| `INSTAGRAM_SESSIONID` | ⚠️ unset | Optional; IG imports without it will hit the graceful-degradation path (action asks you to paste the caption) |

## Triage done in this PR

- Applied `recipe` label to 23 import issues: #4, #7, #12, #13, #14, #15, #16, #18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #31, #32, #33, #36.
- Closed #30 (fulfilled by this PR), #39 (obsoleted by [df9967a](https://github.com/lucharo/recipe-portfolio/commit/df9967a)), #2 (retired alongside the `searchbar` branch).
- Deleted remote `searchbar` branch (last touched mid-2023, pre-redesign MUI code).
- Left active feature requests open: #6, #10, #11, #34, #35, #37, #38.

## Deferred

- **Smoke tests** (#33 blog, #31 YouTube) — the `gh workflow run` API only sees workflows on the default branch, so smoke testing must happen post-merge. Plan after merge: dispatch for #33, confirm variants look good, `/use N`, verify the resulting PR, repeat for #31.
- **Dependabot CRA→Vite migration** — 52 alerts, all transitive through `react-scripts`. Separate PR.
- **Instagram smoke test (#26)** — blocked on setting `INSTAGRAM_SESSIONID` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)