### PR TITLE
Add grid/list view toggle to gallery

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { AppState, Recipe, RecipeDB, Theme } from "./types";
+import type { AppState, Recipe, RecipeDB, Theme, ViewMode } from "./types";
 import TopBar from "./TopBar";
 import Gallery from "./Gallery";
 import RecipeView from "./Recipe";
@@ -12,6 +12,7 @@ const DEFAULT_STATE: AppState = {
   route: "gallery",
   slug: null,
   theme: "light",
+  viewMode: "grid",
 };
 
 const toSlug = (name: string): string =>
@@ -27,6 +28,7 @@ const loadState = (): AppState => {
       route: saved.route ?? DEFAULT_STATE.route,
       slug: saved.slug ?? DEFAULT_STATE.slug,
       theme: saved.theme ?? saved.tweaks?.theme ?? DEFAULT_STATE.theme,
+      viewMode: saved.viewMode ?? DEFAULT_STATE.viewMode,
     };
   } catch {
     return DEFAULT_STATE;
@@ -40,7 +42,12 @@ const App: React.FC = () => {
   React.useEffect(() => {
     localStorage.setItem(
       LS_KEY,
-      JSON.stringify({ route: state.route, slug: state.slug, theme: state.theme })
+      JSON.stringify({
+        route: state.route,
+        slug: state.slug,
+        theme: state.theme,
+        viewMode: state.viewMode,
+      })
     );
   }, [state]);
 
@@ -50,6 +57,7 @@ const App: React.FC = () => {
   }, [state.theme]);
 
   const setTheme = (theme: Theme) => setState((s) => ({ ...s, theme }));
+  const setViewMode = (viewMode: ViewMode) => setState((s) => ({ ...s, viewMode }));
   const openRecipe = (r: Recipe) =>
     setState((s) => ({ ...s, route: "recipe", slug: toSlug(r.name) }));
   const goHome = () => setState((s) => ({ ...s, route: "gallery", slug: null }));
@@ -62,7 +70,14 @@ const App: React.FC = () => {
     <>
       <TopBar theme={state.theme} setTheme={setTheme} onHome={goHome} />
 
-      {state.route === "gallery" && <Gallery recipes={recipes} onOpen={openRecipe} />}
+      {state.route === "gallery" && (
+        <Gallery
+          recipes={recipes}
+          onOpen={openRecipe}
+          viewMode={state.viewMode}
+          setViewMode={setViewMode}
+        />
+      )}
 
       {state.route === "recipe" && currentRecipe && (
         <RecipeView recipe={currentRecipe} onBack={goHome} />

--- a/src/Gallery.tsx
+++ b/src/Gallery.tsx
@@ -1,13 +1,16 @@
 import React from "react";
-import type { Recipe } from "./types";
+import type { Recipe, ViewMode } from "./types";
 import RecipePlaceholder from "./RecipePlaceholder";
+import Icon from "./Icon";
 
 interface GalleryProps {
   recipes: Recipe[];
   onOpen: (r: Recipe) => void;
+  viewMode: ViewMode;
+  setViewMode: (m: ViewMode) => void;
 }
 
-const Gallery: React.FC<GalleryProps> = ({ recipes, onOpen }) => {
+const Gallery: React.FC<GalleryProps> = ({ recipes, onOpen, viewMode, setViewMode }) => {
   return (
     <main style={{ maxWidth: 1240, margin: "0 auto", padding: "40px 24px 80px", width: "100%" }}>
       <section style={{ marginBottom: 36 }}>
@@ -44,7 +47,7 @@ const Gallery: React.FC<GalleryProps> = ({ recipes, onOpen }) => {
       <div
         style={{
           display: "flex",
-          alignItems: "baseline",
+          alignItems: "center",
           gap: 12,
           marginBottom: 20,
           paddingBottom: 10,
@@ -66,20 +69,30 @@ const Gallery: React.FC<GalleryProps> = ({ recipes, onOpen }) => {
         <span style={{ color: "var(--fg-3)", fontFamily: "var(--mono)", fontSize: 12 }}>
           ({recipes.length})
         </span>
+        <div style={{ flex: 1 }} />
+        <ViewToggle viewMode={viewMode} setViewMode={setViewMode} />
       </div>
 
-      <div
-        className="rp-grid"
-        style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
-          gap: 18,
-        }}
-      >
-        {recipes.map((r) => (
-          <RecipeCard key={r.name} recipe={r} onOpen={onOpen} />
-        ))}
-      </div>
+      {viewMode === "grid" ? (
+        <div
+          className="rp-grid"
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fill, minmax(220px, 1fr))",
+            gap: 18,
+          }}
+        >
+          {recipes.map((r) => (
+            <RecipeCard key={r.name} recipe={r} onOpen={onOpen} />
+          ))}
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          {recipes.map((r) => (
+            <RecipeRow key={r.name} recipe={r} onOpen={onOpen} />
+          ))}
+        </div>
+      )}
 
       <footer
         style={{
@@ -158,6 +171,109 @@ const RecipeCard: React.FC<CardProps> = ({ recipe, onOpen }) => (
       }}
     >
       {recipe.methods.length} steps · {recipe.ingredients.length} ingredients
+    </div>
+  </article>
+);
+
+interface ViewToggleProps {
+  viewMode: ViewMode;
+  setViewMode: (m: ViewMode) => void;
+}
+
+const ViewToggle: React.FC<ViewToggleProps> = ({ viewMode, setViewMode }) => {
+  const btn = (mode: ViewMode, icon: "grid" | "list", label: string) => {
+    const active = viewMode === mode;
+    return (
+      <button
+        onClick={() => setViewMode(mode)}
+        title={label}
+        aria-label={label}
+        aria-pressed={active}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          justifyContent: "center",
+          width: 28,
+          height: 28,
+          borderRadius: 3,
+          border: "1px solid",
+          borderColor: active ? "var(--rule)" : "transparent",
+          background: active ? "var(--rule-soft)" : "transparent",
+          color: active ? "var(--fg)" : "var(--fg-3)",
+        }}
+      >
+        <Icon name={icon} size={14} />
+      </button>
+    );
+  };
+  return (
+    <div style={{ display: "inline-flex", gap: 4 }}>
+      {btn("grid", "grid", "grid view")}
+      {btn("list", "list", "list view")}
+    </div>
+  );
+};
+
+const RecipeRow: React.FC<CardProps> = ({ recipe, onOpen }) => (
+  <article
+    onClick={() => onOpen(recipe)}
+    style={{
+      cursor: "pointer",
+      display: "flex",
+      alignItems: "center",
+      gap: 14,
+      padding: "10px 4px",
+      borderBottom: "1px dashed var(--rule-soft)",
+    }}
+    onMouseEnter={(e) => {
+      const t = e.currentTarget.querySelector<HTMLHeadingElement>(".row-title");
+      if (t) t.style.color = "var(--accent)";
+    }}
+    onMouseLeave={(e) => {
+      const t = e.currentTarget.querySelector<HTMLHeadingElement>(".row-title");
+      if (t) t.style.color = "var(--fg)";
+    }}
+  >
+    <div
+      style={{
+        width: 56,
+        height: 56,
+        flexShrink: 0,
+        overflow: "hidden",
+        borderRadius: 4,
+        border: "1px solid var(--rule-soft)",
+      }}
+    >
+      <RecipePlaceholder recipe={recipe} />
+    </div>
+    <div style={{ display: "flex", flexDirection: "column", minWidth: 0, flex: 1 }}>
+      <h3
+        className="row-title"
+        style={{
+          fontFamily: "var(--mono)",
+          fontSize: 14,
+          fontWeight: 700,
+          margin: 0,
+          lineHeight: 1.25,
+          transition: "color 0.15s ease",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {recipe.name.toLowerCase()}
+      </h3>
+      <div
+        style={{
+          fontFamily: "var(--mono)",
+          fontSize: 11,
+          color: "var(--fg-3)",
+          marginTop: 3,
+        }}
+      >
+        {recipe.methods.length} steps · {recipe.ingredients.length} ingredients
+        {recipe.creator ? ` · ${recipe.creator.toLowerCase()}` : ""}
+      </div>
     </div>
   </article>
 );

--- a/src/Icon.tsx
+++ b/src/Icon.tsx
@@ -2,7 +2,8 @@ import React from "react";
 
 type IconName =
   | "sun" | "moon" | "play" | "stop" | "x"
-  | "arrow-left" | "arrow-right" | "external" | "github" | "home";
+  | "arrow-left" | "arrow-right" | "external" | "github" | "home"
+  | "grid" | "list";
 
 interface IconProps {
   name: IconName;
@@ -81,6 +82,21 @@ const Icon: React.FC<IconProps> = ({ name, size = 16, stroke = 1.6 }) => {
       return (
         <svg {...common}>
           <path d="M3 10l9-7 9 7v11a2 2 0 0 1-2 2h-4v-7h-6v7H5a2 2 0 0 1-2-2z" />
+        </svg>
+      );
+    case "grid":
+      return (
+        <svg {...common}>
+          <rect x="3" y="3" width="7" height="7" rx="1" />
+          <rect x="14" y="3" width="7" height="7" rx="1" />
+          <rect x="3" y="14" width="7" height="7" rx="1" />
+          <rect x="14" y="14" width="7" height="7" rx="1" />
+        </svg>
+      );
+    case "list":
+      return (
+        <svg {...common}>
+          <path d="M8 6h13M8 12h13M8 18h13M3.5 6h.01M3.5 12h.01M3.5 18h.01" />
         </svg>
       );
     default:

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,8 +23,11 @@ export interface RecipeDB {
 
 export type Theme = "light" | "dark";
 
+export type ViewMode = "grid" | "list";
+
 export interface AppState {
   route: "gallery" | "recipe";
   slug: string | null;
   theme: Theme;
+  viewMode: ViewMode;
 }


### PR DESCRIPTION
Toggle to the right of the recipes header switches the gallery between grid (current) and a list layout (thumbnail + title rows). Choice persists via localStorage alongside theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)